### PR TITLE
Fix: Icinga for Windows module path validation

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Icinga GmbH")]
 [assembly: AssemblyProduct("Icinga for Windows Service")]
-[assembly: AssemblyCopyright("Copyright © Icinga GmbH 2022")]
+[assembly: AssemblyCopyright("Copyright © Icinga GmbH 2025")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/icinga-service.csproj
+++ b/icinga-service.csproj
@@ -27,7 +27,7 @@
     <ProductName>Icinga for Windows Service</ProductName>
     <PublisherName>Icinga GmbH</PublisherName>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.2.0.%2a</ApplicationVersion>
+    <ApplicationVersion>1.3.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>

--- a/src/main/Program.cs
+++ b/src/main/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.ServiceProcess;
 using System.Text;
 
@@ -15,10 +17,17 @@ namespace IcingaForWindows
             if (args.Length > 0) {
                 module = args[0];
             }
-            
+
+            IcingaForWindows ifw = new IcingaForWindows(module);
+
+            // Ensure our module path is valid
+            if (ifw.DoesFrameworkExist() == false) {
+                Environment.Exit(1);
+            }
+
             ServiceBase[] ServicesToRun;
             ServicesToRun = new ServiceBase[] {
-                new IcingaForWindows(module)
+                ifw
             };
             ServiceBase.Run(ServicesToRun);
         }

--- a/src/main/icingaforwindows.cs
+++ b/src/main/icingaforwindows.cs
@@ -21,6 +21,15 @@ namespace IcingaForWindows
             this.m_agent      = new Agent(this.m_modulePath);
         }
 
+        public bool DoesFrameworkExist()
+        {
+            if (this.m_agent == null) {
+                return false;
+            }
+
+            return this.m_agent.DoesFrameworkExist();
+        }
+
         protected override void OnStart(string[] args)
         {
             this.m_agent.StartAgent();


### PR DESCRIPTION
Fixes the Icinga for Windows service to properly validate the given path pointing for the Icinga PowerShell Framework, exiting with an error if not present or found